### PR TITLE
SEC-DED in L0 cache

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -14,6 +14,7 @@ dependencies:
   reqrsp_interface:     { path: "hardware/deps/reqrsp_interface"                                            }
   snitch:               { path: "hardware/deps/snitch"                                                      }
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git",   version: 0.2.5  }
+  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells",         version: 0.5.1  }
 
 workspace:
   checkout_dir: "./hardware/deps"

--- a/hardware/deps/snitch/Bender.yml
+++ b/hardware/deps/snitch/Bender.yml
@@ -7,8 +7,9 @@ package:
   authors: [ "Florian Zaruba <zarubaf@iis.ee.ethz.ch>" ]
 
 dependencies:
-  axi:          { git: "https://github.com/pulp-platform/axi.git",          version: 0.36.0 }
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.19.0 }
+  axi:              { git: "https://github.com/pulp-platform/axi.git",          version: 0.36.0 }
+  common_cells:     { git: "https://github.com/pulp-platform/common_cells.git", version: 1.19.0 }
+  redundancy_cells: { git: "https://github.com/pulp-platform/redundancy_cells", version: 0.5.1  }
 
 sources:
   - defines:

--- a/hardware/deps/snitch/src/snitch_icache/snitch_icache_handler.sv
+++ b/hardware/deps/snitch/src/snitch_icache/snitch_icache_handler.sv
@@ -214,7 +214,7 @@ module snitch_icache_handler #(
                 in_req_ready_o = hit_ready;
 
             // The cache lookup was a miss, but there is already a pending
-            // refill that covers the line.
+            // refill that covers the line and the lookup accepted the request.
             end else if (pending && !(write_valid_o && !write_ready_i)) begin
                 push_index  = pending_id;
                 push_enable = 1;

--- a/hardware/deps/snitch/src/snitch_icache/snitch_icache_l0.sv
+++ b/hardware/deps/snitch/src/snitch_icache/snitch_icache_l0.sv
@@ -168,7 +168,7 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
     for (genvar j = 0; j < CFG.LINE_WIDTH/CFG.FETCH_DW; j++) begin: gen_enc
       prim_secded_39_32_enc i_enc_39_32 (
         .in(out_rsp_data_i[CFG.LINE_WIDTH - CFG.FETCH_DW*j -1 -: CFG.FETCH_DW]),
-        .out(data_encoded[256+56 - 1 - (39)*j -: (39)])
+        .out(data_encoded[256+56 - 1 - (39)*j -: (39)])  //CFG.LINE_WIDTH + DATA_PARITY_WIDTH -1 - (CFG.FETCH_DW+7)*j -:(CFG.FETCH_DW+7)
       );
     end 
   end
@@ -264,7 +264,7 @@ module snitch_icache_l0 import snitch_icache_pkg::*; #(
       for (genvar j = 0; j < CFG.LINE_WIDTH/CFG.FETCH_DW; j++) begin: gen_enc
         prim_secded_39_32_dec i_dec_39_32 (
           .in(data[i][CFG.LINE_WIDTH + DATA_PARITY_WIDTH - (CFG.FETCH_DW+7)*j -1 -: (CFG.FETCH_DW+7)]),
-          .d_o(data_decoded[i][256 - 32*j -1 -: CFG.FETCH_DW]),
+          .d_o(data_decoded[i][256 - 32*j -1 -: CFG.FETCH_DW]), //CFG.LINE_WIDTH - CFG.FETCH_DW*j -1 -: CFG.FETCH_DW
           .syndrome_o(),
           .err_o(data_errors[i][j])
         );

--- a/hardware/deps/snitch/tb/README.md
+++ b/hardware/deps/snitch/tb/README.md
@@ -1,0 +1,16 @@
+## Read-only cache test bench
+
+This folder contains the test bench for the read-only cache and the fault injection scripts to test the fault tolerance mechanism. 
+Faults are injected on the tag and data lines inside the lookup module.
+
+In order to test fault detection on the tag lines, a fault can be injected only on the parity bits, otherwise it will be treated as a miss.
+To test fault detection on the data lines, each line is added separately to the list of signals where to inject faults.
+
+In order to test for the faults, the dimensions inside the `mempool/hardware/deps/snitch/tb/fault_injection/ROC_inject_fault.tcl` file have to be updated.
+
+Usage: 
+
+```bash
+cd questa
+questa-2022.3 vsim -do ../FI_sim_setup.tcl
+```

--- a/hardware/deps/snitch/tb/fault_injection/ROC_inject_fault.tcl
+++ b/hardware/deps/snitch/tb/fault_injection/ROC_inject_fault.tcl
@@ -42,11 +42,12 @@ set max_tag_line_index 47 ; # Replace with the actual maximum value
 #debug 57, normal 47
 
 # Add the signal paths with maximum indices to the inject_register_netlist
+# Do not add the tag signal without indexes, as it flips entire lines to 0
+# To check tag functionality, we invert only the parity bit, which is the last one
 for {set index $max_index_value} {$index >= 0} {incr index -1} {
     set signal_path "${itag_sram_path}[${index}][${max_tag_line_index}]"
     lappend inject_register_netlist $signal_path
 }
-#lappend inject_register_netlist /snitch_read_only_cache_tb/dut/i_lookup/i_data/sram #do not do this: it flips entire registers to zero
 
 #set max_data_index 63;
 set max_data_index [expr {
@@ -57,13 +58,6 @@ for {set index $max_data_index} {$index >= 0} {incr index -1} {
     set signal_path "${idata_sram_path}[${index}]"
     lappend inject_register_netlist $signal_path
 }
-
-#lappend inject_register_netlist /snitch_read_only_cache_tb/dut/i_lookup/i_data/sram[63]
-
-
-#/snitch_read_only_cache_tb/dut/i_lookup/i_data/sram
-#/snitch_read_only_cache_tb/dut/i_lookup/gen_sram/i_tag/sram
-
 
 set inject_signals_netlist []
 set output_netlist []

--- a/hardware/scripts/questa/README.md
+++ b/hardware/scripts/questa/README.md
@@ -14,7 +14,7 @@ app=hello_world icache_faults=1 make sim
 ```
 
 
-## Get the number of faults that the Snitch Lookup had to deal with
+### Get the number of faults that the Snitch Lookup had to deal with
 
 After the simulation finishes, it is possible to get the information on how many faults were detected.
 

--- a/hardware/scripts/questa/README.md
+++ b/hardware/scripts/questa/README.md
@@ -1,0 +1,27 @@
+## Testing MemPool with Fault Injection
+
+The fault injection scripts (`inject_fault.tcl`, `extract_nets.tcl`) are called by the script `mempool_inject_fault.tcl`.
+In this script, the signals under fault injection must be listed and the parameters modified.
+
+This can be done with the `find signal` command in Questa, but for packed arrays this approach does not work.
+
+Therefore, the full signal path is appended to the instance path of the modules containing the cache. This is done in the script `get_banks.tcl`.
+
+To run the simulation, in the script `mempool_inject_fault.tcl` adapt the list of nets where to inject faults. Then, in the hardware folder run the following command:
+
+```bash
+app=hello_world icache_faults=1 make sim
+```
+
+
+## Get the number of faults that the Snitch Lookup had to deal with
+
+After the simulation finishes, it is possible to get the information on how many faults were detected.
+
+In the Questa command line, run the following script:
+
+```bash
+do ../script/questa/get_number_faults.tcl
+```
+
+This script generates a file `mempool/hardware/build/data_tag_faults_stats.txt` listing, for each lookup modules, how many tag and data faults occurred. It also computes the average value across all modules.

--- a/hardware/scripts/questa/get_banks.tcl
+++ b/hardware/scripts/questa/get_banks.tcl
@@ -1,3 +1,6 @@
+# This script produces a list of the tag and data nets in the L0, L1 and RO cache.
+# Optionally, these can be saved in a file.
+
 # Search for all instances of tag banks for ROC
 set pattern_match "*/i_snitch_read_only_cache/i_lookup/gen_sram/i_tag*" ;
 # Get the list of instance paths
@@ -11,6 +14,7 @@ foreach inst $inst_list {
  lappend ROC_tag_list $ipath
  }
 }
+
 # At this point, ROC_tag_list contains the list of instances only--
 # no architecture names
 #
@@ -28,7 +32,7 @@ foreach inst $inst_list {
 
 
 
-# Search for all instances of tag banks for L1I
+# Search for all instances of tag banks for L1 IC
 set pattern_match "*]/i_tag*"
 set inst_list [find instances -r $pattern_match] ;
 set L1_tag_list [list] ;
@@ -68,7 +72,7 @@ foreach inst $inst_list {
 
 
 
-# Search for all instances of data banks for L1I
+# Search for all instances of data banks for L1 IC
 set pattern_match "*/i_snitch_icache/i_lookup/i_data*"
 set inst_list [find instances -r $pattern_match] ;
 set L1_data_list [list] ;
@@ -87,7 +91,7 @@ foreach inst $inst_list {
 #close $fhandle ; 
 
 
-# Search for all instances of tag banks for L0
+# Search for all instances of tag banks for L0 IC
 set pattern_match "*i_snitch_icache_l0"
 set inst_list [find instances -r $pattern_match] ;
 set L0_tag_list [list] ;
@@ -99,7 +103,7 @@ foreach inst $inst_list {
  }
 }
 
-# Search for all instances of data banks for L0
+# Search for all instances of data banks for L0 IC
 set pattern_match "*i_snitch_icache_l0"
 set inst_list [find instances -r $pattern_match] ;
 set L0_data_list [list] ;

--- a/hardware/scripts/questa/mempool_inject_fault.tcl
+++ b/hardware/scripts/questa/mempool_inject_fault.tcl
@@ -21,30 +21,18 @@ set check_core_output_modification 0
 set check_core_next_state_modification 0
 set reg_to_sig_ratio 1
 
-#proc base_path {} {return "/snitch_read_only_cache_tb/dut/i_lookup/gen_sram/i_tag"} 
 source ${::script_base_path}get_banks.tcl
-
-#proc add_signals_injection {tag_list tag_idx tag_max_width data_list no_databanks} {
-#    foreach inst $tag_list {
-#        for {set index $tag_idx} {$index >= 0} {incr index -1} {
-#            set signal_path "${inst}[${index}][${tag_max_width}]"
-#            lappend inject_register_netlist $signal_path
-#        }
-#    }
-#    foreach inst $data_list {
-#        for {set index $no_databanks} {$index >= 0} {incr index -1} {
-#            set signal_path "${inst}[${index}]"
-#            lappend inject_register_netlist $signal_path
-#        }
-#    }
-#}
 set inject_register_netlist {}
+
+# Tag fault injection on Snitch Instruction Cache
+# how many lines in the tag banks
 set max_idx_icache 31
+# length of tag banks line
 set max_tag_width_icache 25
-
+# lines in the data banks
 set no_banks_icache 63
-#add_signals_injection $L1_tag_list $max_idx_icache $max_tag_width_icache $L1_data_list $no_banks_icache
 
+# To check error detection on the tag, inject faults only on the parity bits. To check performance, inject on the entire line.
     foreach inst $L1_tag_list {
         for {set index $max_idx_icache} {$index >= 0} {incr index -1} {
             set signal_path "${inst}[${index}]"
@@ -59,11 +47,10 @@ set no_banks_icache 63
         }
     }
 
+# Tag fault injection on Snitch RO Cache
 set max_idx_rocache 63
 set max_tag_width_rocache 47
-
 set no_banks_rocache 127
-#add_signals_injection $ROC_tag_list $max_idx_rocache $max_tag_width_rocache $L1_data_list $no_banks_rocache
 
     foreach inst $ROC_tag_list {
         for {set index $max_idx_rocache} {$index >= 0} {incr index -1} {
@@ -79,6 +66,7 @@ set no_banks_rocache 127
         }
     }
 
+# Tag fault injection in the L0 Cache, unfortunately not working correctly due to a bug. See fault injection script for more details.
 set max_idx_l0cache 3
 set max_tag_width_l0cache 27
 set no_banks_l0cache 3
@@ -99,7 +87,7 @@ set no_banks_l0cache 3
     }
 
 
-#random shuffle of the list
+# Random shuffle of the list, the log showed that fault injection script is not so random in picking the signals
 for {set i 0} {$i < [llength $inject_register_netlist]} {incr i} {
     set j [expr {int(rand() * [llength $inject_register_netlist])}]
     set temp [lindex $inject_register_netlist $j]

--- a/hardware/scripts/questa/run.tcl
+++ b/hardware/scripts/questa/run.tcl
@@ -4,18 +4,11 @@
 set allow_faults 1
 #[lindex $argv 0]
 
-if {$::env(icache_faults)  ==1} {
+# Run the fault injection script
+if {$::env(icache_faults)  == 1} {
     source ../scripts/questa/mempool_inject_fault.tcl
-
 }
 do ../scripts/questa/wave.tcl
-add wave -Group gr1_axitocache {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[1]/i_group/i_axi_interco/gen_bottom_level/gen_ro_cache/i_snitch_read_only_cache/i_axi_to_cache/*}
-add wave -Group gr1_lookup {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[1]/i_group/i_axi_interco/gen_bottom_level/gen_ro_cache/i_snitch_read_only_cache/i_lookup/*}
-add wave -Group gr1_roc {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[1]/i_group/i_axi_interco/gen_bottom_level/gen_ro_cache/i_snitch_read_only_cache/*}
-add wave -Group gr1_refill {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[1]/i_group/i_axi_interco/gen_bottom_level/gen_ro_cache/i_snitch_read_only_cache/i_refill/*}
-add wave -Group gr1_handler {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[1]/i_group/i_axi_interco/gen_bottom_level/gen_ro_cache/i_snitch_read_only_cache/i_handler/*}
-add wave -Group gr1_splittertable {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[1]/i_group/i_axi_interco/gen_bottom_level/gen_ro_cache/i_snitch_read_only_cache/i_axi_to_cache/i_axi_burst_splitter_table/*}
-add wave -Group idq {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[1]/i_group/i_axi_interco/gen_bottom_level/gen_ro_cache/i_snitch_read_only_cache/i_axi_to_cache/i_axi_burst_splitter_table/i_idq/*}
-add wave -Group gr0_l0 {sim:/mempool_tb/dut/i_mempool_cluster/gen_groups[0]/i_group/gen_tiles[0]/i_tile/gen_caches[0]/i_snitch_icache/gen_prefetcher[0]/i_snitch_icache_l0/*}
+
 log -r /*
 run -a


### PR DESCRIPTION
Made L0 cache reliable using encoders/decoders of the redundancy cells 

## Changelog
Changed the L0 instruction cache

### Added

### Changed

### Fixed

(Reference to issues, labels, and related merge requests)

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
